### PR TITLE
Fix css tag selector

### DIFF
--- a/java/client/src/org/openqa/selenium/remote/http/W3CHttpCommandCodec.java
+++ b/java/client/src/org/openqa/selenium/remote/http/W3CHttpCommandCodec.java
@@ -130,7 +130,7 @@ public class W3CHttpCommandCodec extends AbstractHttpCommandCodec {
 
           case "tag name":
             toReturn.put("using", "css selector");
-            toReturn.put("value", "#" + cssEscape(value));
+            toReturn.put("value", cssEscape(value));
             break;
 
           case "xpath":


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

The css selector for tags was falsely prefixed with the id selector.
